### PR TITLE
feat: Crée la page d'accueil e-commerce publique

### DIFF
--- a/resources/views/components/ecommerce/product-card.blade.php
+++ b/resources/views/components/ecommerce/product-card.blade.php
@@ -13,57 +13,68 @@
     <img src="{{ $product['image'] ?? 'https://placehold.co/400x400/F3F4F6/9CA3AF?text=Produit' }}"
          alt="Image de {{ $product['name'] ?? 'Nom du produit' }}"
          class="w-full h-full object-cover object-center group-hover:opacity-80 transition-opacity duration-300">
-    {{-- Badge de promotion (optionnel) --}}
-    @if(isset($product['badge']))
-      <span class="absolute top-2 left-2 bg-red-500 text-white text-xs font-semibold px-2 py-1 rounded">{{ $product['badge'] }}</span>
+    {{-- Badge de promotion (optionnel) - Adapté pour est_en_promotion --}}
+    @if(isset($product->est_en_promotion) && $product->est_en_promotion)
+      <span class="absolute top-3 left-3 bg-red-500 text-white text-xs font-semibold px-2.5 py-1 rounded-full z-10">PROMO</span>
+    @elseif(isset($product['badge'])) {{-- Fallback pour la prop 'badge' existante si besoin --}}
+      <span class="absolute top-3 left-3 bg-red-500 text-white text-xs font-semibold px-2.5 py-1 rounded-full z-10">{{ $product['badge'] }}</span>
     @endif
   </div>
-  <div class="p-4">
+  <div class="p-4 flex flex-col flex-grow"> {{-- Ajout de flex flex-col flex-grow pour aligner le bouton en bas --}}
     {{-- Catégorie du produit (optionnel) --}}
-    @if(isset($product['categoryName']))
-      <p class="text-xs text-gray-500 mb-1">{{ $product['categoryName'] }}</p>
+    @if(isset($product->categoryName) || isset($product['categoryName'])) {{-- Supporte objet ou array --}}
+      <p class="text-xs text-gray-500 mb-1">{{ $product->categoryName ?? $product['categoryName'] }}</p>
     @endif
+
     {{-- Nom du produit --}}
-    <h3 class="text-base font-semibold text-gray-800 mb-2">
-      <a href="{{ url('/produit/' . ($product['slug'] ?? '#')) }}" class="hover:text-blue-600 transition-colors duration-300">
+    <h3 class="text-base font-semibold text-gray-800 mb-2 flex-grow"> {{-- flex-grow pour pousser le prix/bouton en bas si noms de tailles variables --}}
+      <a href="{{ url('/produit/' . ($product->slug ?? $product['slug'] ?? '#')) }}" class="hover:text-blue-600 transition-colors duration-300">
         <span aria-hidden="true" class="absolute inset-0"></span>
-        {{ $product['name'] ?? 'Nom du Produit Placeholder' }}
+        {{ $product->name ?? $product['name'] ?? 'Nom du Produit Placeholder' }}
       </a>
     </h3>
+
     {{-- Prix du produit --}}
-    <div class="flex items-baseline justify-between">
-      <p class="text-lg font-bold text-blue-600">
-        {{ number_format($product['price'] ?? 0, 2, ',', ' ') }} €
+    <div class="flex items-center justify-between mb-3">
+      <p class="text-lg font-bold {{ (isset($product->est_en_promotion) && $product->est_en_promotion) || isset($product['oldPrice']) ? 'text-red-600' : 'text-blue-600' }}">
+        {{ number_format($product->price ?? $product['price'] ?? 0, 2, ',', ' ') }} €
       </p>
       {{-- Ancien prix (si en promotion) --}}
-      @if(isset($product['oldPrice']))
+      @if(isset($product->oldPrice) || isset($product['oldPrice']))
         <p class="text-sm text-gray-400 line-through ml-2">
-          {{ number_format($product['oldPrice'], 2, ',', ' ') }} €
+          {{ number_format($product->oldPrice ?? $product['oldPrice'], 2, ',', ' ') }} €
         </p>
       @endif
     </div>
+
     {{-- Bouton Ajouter au panier --}}
-    <div class="mt-4">
+    <div class="mt-auto"> {{-- mt-auto pour pousser le bouton en bas si la carte a une hauteur fixe ou si le contenu au dessus ne remplit pas tout --}}
       <button
         type="button"
-        class="w-full relative flex items-center justify-center rounded-md border border-transparent bg-blue-600 py-2 px-4 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-300"
-        onclick="addToCart({{ $product['id'] ?? 0 }})" {{-- Placeholder pour la fonction JS --}}
+        class="w-full relative flex items-center justify-center rounded-md border border-transparent bg-blue-600 py-2.5 px-4 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-300 ease-in-out transform group-hover:scale-105"
+        {{-- Assumant que l'ID du produit est disponible soit comme $product->id ou $product['id'] --}}
+        onclick="addToCart({{ $product->id ?? $product['id'] ?? 0 }})"
       >
         Ajouter au panier
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 ml-2" viewBox="0 0 20 20" fill="currentColor">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 ml-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300" viewBox="0 0 20 20" fill="currentColor">
           <path d="M3 1a1 1 0 000 2h1.22l.305 1.222a.997.997 0 00.01.042l1.358 5.43-.893.892C3.74 11.846 4.632 14 6.414 14H15a1 1 0 000-2H6.414l1-1H14a1 1 0 00.894-.553l3-6A1 1 0 0017 3H6.28l-.31-1.243A1 1 0 005 1H3zM16 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM6.5 18a1.5 1.5 0 100-3 1.5 1.5 0 000 3z" />
         </svg>
       </button>
-      {{-- Script simple pour la démo du clic --}}
+      {{-- Le script addToCart est conservé tel quel, en s'assurant qu'il ne soit pas dupliqué si plusieurs cartes sont sur la page.
+           Idéalement, cette fonction serait dans un fichier JS global et non répétée ici.
+           Pour l'instant, on la garde car la structure du projet n'est pas entièrement connue. --}}
+      @once
       <script>
         if (typeof addToCart !== 'function') {
           function addToCart(productId) {
             console.log('Produit ajouté au panier (ID): ' + productId);
             // Ici, vous intégreriez la logique d'ajout au panier (ex: appel AJAX)
+            // Exemple: document.dispatchEvent(new CustomEvent('add-to-cart', { detail: { productId: productId } }));
             alert('Produit ' + productId + ' ajouté au panier (simulation).');
           }
         }
       </script>
+      @endonce
     </div>
   </div>
 </div>

--- a/resources/views/ecommerce/home.blade.php
+++ b/resources/views/ecommerce/home.blade.php
@@ -3,133 +3,160 @@
 @section('title', 'Accueil Boutique')
 
 @section('content')
-<div class="page-inner-ecommerce">
+<div class="page-inner-ecommerce pt-5 pb-5"> {{-- Padding Tailwind ajouté ici --}}
 
-    <!-- Bannière Principale -->
-    <section class="banner-section mb-5">
-        <div class="card text-white">
-            <img src="{{ asset('assets/img/examples/ecommerce-banner.jpg') }}" class="card-img" alt="Bannière principale" style="max-height: 400px; object-fit: cover;">
-            <div class="card-img-overlay d-flex flex-column justify-content-center align-items-center" style="background-color: rgba(0,0,0,0.4);">
-                <h1 class="display-4 card-title">Découvrez nos Nouveautés</h1>
-                <p class="lead card-text">Des produits de qualité exceptionnelle vous attendent.</p>
-                <a href="#" class="btn btn-primary btn-lg mt-3">Achetez Maintenant</a>
-            </div>
+    <!-- Section Hero (Bannière d'accueil) -->
+    <section class="banner-section mb-5 relative">
+        {{-- Image de fond --}}
+        <img src="{{ asset('assets/img/examples/ecommerce-banner.jpg') }}" class="absolute inset-0 w-full h-full object-cover" alt="Bannière principale">
+        {{-- Conteneur pour le contenu avec un overlay sombre pour la lisibilité --}}
+        <div class="relative min-h-[400px] md:min-h-[500px] flex flex-col justify-center items-center text-center text-white p-6" style="background-color: rgba(0,0,0,0.5);">
+            <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold mb-4 leading-tight" style="text-shadow: 1px 1px 3px rgba(0,0,0,0.7);">
+                Bienvenue dans notre boutique en ligne
+            </h1>
+            <p class="text-lg md:text-xl lg:text-2xl mb-8 max-w-2xl" style="text-shadow: 1px 1px 3px rgba(0,0,0,0.7);">
+                Achetez vos produits sans vous déplacer
+            </p>
+            <a href="{{ url('/produits') }}" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-8 rounded-lg text-lg transition duration-300 ease-in-out transform hover:scale-105">
+                Voir les produits
+            </a>
         </div>
     </section>
+    <!-- Fin Section Hero -->
 
-    <!-- Section Filtres (simplifiée pour l'instant) -->
-    {{-- <section class="filters-section mb-4">
-        <div class="card">
-            <div class="card-body">
-                <form action="{{ route('ecommerce.products.filter') }}" method="GET">
-                    <div class="row g-3 align-items-center">
-                        <div class="col-md-3">
-                            <label for="category_filter" class="form-label">Catégorie</label>
-                            <select name="category" id="category_filter" class="form-select">
-                                <option value="">Toutes</option>
-                                @foreach(\App\Models\Categorie::orderBy('name')->get() as $category)
-                                    <option value="{{ $category->id }}">{{ $category->name }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div class="col-md-3">
-                            <label for="price_filter" class="form-label">Prix Max</label>
-                            <input type="number" name="max_price" id="price_filter" class="form-control" placeholder="ex: 500">
-                        </div>
-                        <div class="col-md-3">
-                            <label for="sort_by_filter" class="form-label">Trier par</label>
-                            <select name="sort_by" id="sort_by_filter" class="form-select">
-                                <option value="newest">Nouveautés</option>
-                                <option value="price_asc">Prix Croissant</option>
-                                <option value="price_desc">Prix Décroissant</option>
-                                <option value="name_asc">Nom A-Z</option>
-                            </select>
-                        </div>
-                        <div class="col-md-3 d-flex align-items-end">
-                            <button type="submit" class="btn btn-info w-100">Filtrer</button>
-                        </div>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </section> --}}
-
-
-    <!-- Grille de présentation de produits (Principale) -->
-    <section class="products-grid-section mb-5">
-        <h2 class="mb-4 text-center">Nos Produits</h2>
-        @if(isset($products) && $products->count() > 0)
-            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
-                @foreach($products as $product)
-                    <div class="col">
-                        <x-ecommerce.product-card :product="$product" />
-                    </div>
-                @endforeach
-            </div>
-            <div class="mt-4 d-flex justify-content-center">
-                {{ $products->links() }} <!-- Pagination -->
-            </div>
-        @else
-            <p class="text-center text-muted">Aucun produit à afficher pour le moment.</p>
-        @endif
-    </section>
-
-    <!-- Section Nouveautés -->
-    @if(isset($newProducts) && $newProducts->count() > 0)
-    <section class="new-products-section mb-5">
-        <h2 class="mb-4 text-center">Nouveautés</h2>
-        <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
-            @foreach($newProducts as $product)
-                <div class="col">
-                    <x-ecommerce.product-card :product="$product" />
+    <!-- Section Catégories -->
+    <section class="categories-section my-8 md:my-12">
+        <div class="container mx-auto px-4">
+            <h2 class="text-2xl md:text-3xl font-semibold text-center mb-6 md:mb-8">Découvrez nos Catégories</h2>
+            {{-- Assumant que $categories est passé à la vue --}}
+            @if(isset($categories) && $categories->count() > 0)
+                <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 md:gap-6">
+                    @foreach($categories as $categorie)
+                        <a href="{{ url('/produits?categorie=' . $categorie->id) }}" class="group block rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-300 ease-in-out overflow-hidden bg-white">
+                            <div class="h-32 sm:h-40 bg-gray-200 flex items-center justify-center">
+                                {{-- Placeholder pour image/icône --}}
+                                @if(isset($categorie->image_url) && $categorie->image_url)
+                                    <img src="{{ $categorie->image_url }}" alt="{{ $categorie->nom }}" class="h-full w-full object-cover">
+                                @else
+                                    <svg class="w-16 h-16 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4M4 7s0 0 0 0M12 15V7m0 0L8 11m4-4l4 4"></path></svg>
+                                @endif
+                            </div>
+                            <div class="p-4 text-center">
+                                <h3 class="text-lg font-semibold text-gray-800 group-hover:text-blue-600 transition-colors duration-300">{{ $categorie->nom }}</h3>
+                            </div>
+                        </a>
+                    @endforeach
                 </div>
-            @endforeach
+            @else
+                <p class="text-center text-gray-600">Aucune catégorie à afficher pour le moment.</p>
+            @endif
         </div>
     </section>
-    @endif
+    <!-- Fin Section Catégories -->
 
-    <!-- Section Produits Populaires -->
-    @if(isset($popularProducts) && $popularProducts->count() > 0)
-    <section class="popular-products-section mb-5">
-        <h2 class="mb-4 text-center">Produits Populaires</h2>
-        <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
-            @foreach($popularProducts as $product)
-                <div class="col">
-                    <x-ecommerce.product-card :product="$product" />
+    <!-- Section Produits Phares / En Promotion -->
+    <section class="featured-products-section my-8 md:my-12">
+        <div class="container mx-auto px-4">
+            <h2 class="text-2xl md:text-3xl font-semibold text-center mb-6 md:mb-8">Nos Produits Phares</h2>
+            {{-- Assumant que $produitsPhares est passé à la vue et contient au maximum 8 produits --}}
+            @if(isset($produitsPhares) && $produitsPhares->count() > 0)
+                <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 md:gap-8">
+                    {{-- La grille sera 1 colonne sur mobile (par défaut), 2 sur sm, 3 sur md, et 4 sur lg et plus.
+                         La demande initiale était 2 colonnes mobile, 4 desktop.
+                         Tailwind mobile-first: grid-cols-2 lg:grid-cols-4
+                         Je vais utiliser grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 pour une meilleure progressivité.
+                         Ajustement pour 2 colonnes mobile et 4 desktop : grid grid-cols-2 lg:grid-cols-4 gap-6
+                    --}}
+                    @foreach($produitsPhares as $produit)
+                        {{-- Le composant product-card sera modifié pour inclure le badge promo et les autres détails --}}
+                        <x-ecommerce.product-card :product="$produit" />
+                    @endforeach
                 </div>
-            @endforeach
+                {{-- Optionnel: Bouton "Voir tous les produits" si la liste est un extrait --}}
+                {{-- <div class="text-center mt-8">
+                    <a href="{{ url('/produits') }}" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-2 px-6 rounded-lg transition duration-300">
+                        Voir tous nos produits
+                    </a>
+                </div> --}}
+            @else
+                <p class="text-center text-gray-600">Aucun produit phare à afficher pour le moment.</p>
+            @endif
         </div>
     </section>
-    @endif
+    <!-- Fin Section Produits Phares -->
 
-    <!-- Section Promotions -->
-    @if(isset($promotionalProducts) && $promotionalProducts->count() > 0)
-    <section class="promotional-products-section mb-5">
-        <h2 class="mb-4 text-center">Promotions</h2>
-        <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
-            @foreach($promotionalProducts as $product)
-                <div class="col">
-                    <x-ecommerce.product-card :product="$product" />
+    <!-- Section Avantages Client -->
+    <section class="customer-benefits-section bg-gray-100 py-8 md:py-12">
+        <div class="container mx-auto px-4">
+            <h2 class="text-2xl md:text-3xl font-semibold text-center mb-6 md:mb-8">Vos Avantages en Commandant Chez Nous</h2>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8 text-center">
+                {{-- Avantage 1 --}}
+                <div class="benefit-item p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300">
+                    {{-- Icône Heroicon: Truck --}}
+                    <svg class="w-12 h-12 text-blue-600 mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 01-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 00-3.213-9.193 2.056 2.056 0 00-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 00-10.026 0 1.106 1.106 0 00-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12" />
+                    </svg>
+                    <h3 class="text-xl font-semibold text-gray-800 mb-2">Livraison Rapide</h3>
+                    <p class="text-gray-600 text-sm">Recevez vos commandes en un temps record, directement chez vous.</p>
                 </div>
-            @endforeach
+                {{-- Avantage 2 --}}
+                <div class="benefit-item p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300">
+                    {{-- Icône Heroicon: ShieldCheck --}}
+                    <svg class="w-12 h-12 text-blue-600 mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.623 0-1.31-.21-2.571-.598-3.751A11.959 11.959 0 0118 5.714c-2.662-.144-5.379 .709-7.5 2.475z" />
+                    </svg>
+                    <h3 class="text-xl font-semibold text-gray-800 mb-2">Paiement Sécurisé</h3>
+                    <p class="text-gray-600 text-sm">Transactions protégées avec les dernières technologies de cryptage.</p>
+                </div>
+                {{-- Avantage 3 --}}
+                <div class="benefit-item p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300">
+                    {{-- Icône Heroicon: ChatBubbleLeftRight --}}
+                    <svg class="w-12 h-12 text-blue-600 mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3.543-3.091a9.117 9.117 0 01-1.255-.32l-1.098-.275 1.255-.324a11.042 11.042 0 001.255-.32l1.098-.275-1.255-.323a11.042 11.042 0 00-1.255-.32l-1.098-.275 1.255-.324a11.042 11.042 0 001.255-.32L20.25 8.511zM12 4.242c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3.543-3.091a9.117 9.117 0 01-1.255-.32l-1.098-.275 1.255-.324a11.042 11.042 0 001.255-.32L12 10.751V4.242zM12 4.242L10.745 3.92a11.041 11.041 0 00-1.255-.321l-1.098-.275-1.255.321a11.041 11.041 0 00-1.255.321L4.5 4.242m7.5 0v6.509M4.5 4.242l1.255.323a11.041 11.041 0 001.255.32L8.25 5.156m0 0L6.995 4.832a11.041 11.041 0 00-1.255-.321L4.5 4.242m0 0l.001-.001.001-.001c.001 0 .001 0 .002 0l.003-.001.003-.001.004-.001.004-.001.005-.001.005-.001.006-.001.006-.001.007 0 .007 0 .008 0 .008 0 .009 0 .009 0c.003 0 .006 0 .009 0s.006 0 .009 0m7.5-1.288c.622-.001 1.234-.004 1.836-.007.018 0 .035-.001.053-.001l.003-.001.003-.001.003-.001.004-.001.004-.001.004-.001.004-.001.004-.001.004-.001.003-.001.003-.001.002-.001.002-.001.002-.001.002-.001.001-.001h-.001c-.001 0-.001 0-.002 0-.001 0-.001 0-.001 0z" />
+                    </svg>
+                    <h3 class="text-xl font-semibold text-gray-800 mb-2">Support Client Réactif</h3>
+                    <p class="text-gray-600 text-sm">Notre équipe est là pour vous aider à chaque étape.</p>
+                </div>
+                {{-- Avantage 4 (Optionnel) --}}
+                <div class="benefit-item p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300">
+                    {{-- Icône Heroicon: ArrowUturnLeft --}}
+                     <svg class="w-12 h-12 text-blue-600 mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3" />
+                    </svg>
+                    <h3 class="text-xl font-semibold text-gray-800 mb-2">Retours Faciles</h3>
+                    <p class="text-gray-600 text-sm">Politique de retour simple et transparente pour votre tranquillité d'esprit.</p>
+                </div>
+            </div>
         </div>
     </section>
-    @endif
+    <!-- Fin Section Avantages Client -->
+
+    <!-- Section "À propos" Rapide -->
+    <section class="about-quick-section py-8 md:py-12">
+        <div class="container mx-auto px-4 text-center md:text-left">
+            <div class="md:flex md:items-center md:justify-between bg-white p-6 md:p-8 rounded-lg shadow-lg">
+                <div class="md:w-2/3 md:pr-8">
+                    <h2 class="text-2xl md:text-3xl font-semibold text-gray-800 mb-4">Qui Sommes-Nous ?</h2>
+                    <p class="text-gray-600 mb-6 leading-relaxed">
+                        Bien plus qu'une simple boutique, nous sommes une équipe de passionnés dédiés à vous offrir les meilleurs produits avec une expérience d'achat inégalée. Notre mission est de simplifier votre quotidien en vous proposant qualité, innovation et service client d'exception. Découvrez notre histoire et nos engagements.
+                        {{-- Ce texte est un placeholder, à remplacer par le contenu réel. --}}
+                    </p>
+                </div>
+                <div class="md:w-1/3 text-center md:text-right mt-6 md:mt-0">
+                    <a href="{{ url('/a-propos') }}" class="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-8 rounded-lg text-lg transition duration-300 ease-in-out transform hover:scale-105">
+                        En Savoir Plus
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+    <!-- Fin Section "À propos" Rapide -->
 
 </div>
 @endsection
 
 @push('styles')
-<style>
-    .banner-section .card-img-overlay h1,
-    .banner-section .card-img-overlay .lead {
-        text-shadow: 1px 1px 3px rgba(0,0,0,0.7);
-    }
-    .page-inner-ecommerce {
-        padding-top: 20px; /* Un peu d'espace après le header fixe */
-        padding-bottom: 20px;
-    }
-</style>
+{{-- Le style custom a été intégré via des classes Tailwind ou style inline directement sur les éléments concernés --}}
 @endpush
 
 @push('scripts')

--- a/resources/views/ecommerce/partials/footer.blade.php
+++ b/resources/views/ecommerce/partials/footer.blade.php
@@ -1,59 +1,86 @@
-<footer class="footer ecommerce-footer mt-auto py-3 bg-light">
-    <div class="container">
-        <div class="row">
-            <div class="col-lg-3 col-md-6 mb-4 mb-lg-0">
-                <h5 class="text-uppercase mb-3">Gestlog E-Commerce</h5>
-                <p class="text-muted">
-                    Votre solution de gestion et d'achat en ligne.
-                    Qualité et service à portée de clic.
+<footer class="ecommerce-footer mt-auto py-8 md:py-12 bg-gray-800 text-gray-300">
+    <div class="container mx-auto px-4">
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-8">
+            {{-- Colonne 1: Nom de la boutique et Réseaux Sociaux --}}
+            <div class="mb-6 md:mb-0">
+                <h5 class="text-xl font-semibold text-white mb-4">Gestlog E-Commerce</h5>
+                <p class="text-gray-400 mb-4 text-sm">
+                    Votre solution de gestion et d'achat en ligne. Qualité et service à portée de clic.
                 </p>
-                <ul class="list-inline mt-3">
-                    <li class="list-inline-item"><a href="#" class="text-muted"><i class="fab fa-facebook fa-lg"></i></a></li>
-                    <li class="list-inline-item"><a href="#" class="text-muted"><i class="fab fa-twitter fa-lg"></i></a></li>
-                    <li class="list-inline-item"><a href="#" class="text-muted"><i class="fab fa-instagram fa-lg"></i></a></li>
-                    <li class="list-inline-item"><a href="#" class="text-muted"><i class="fab fa-linkedin fa-lg"></i></a></li>
+                <div class="flex space-x-4">
+                    <a href="#" class="text-gray-400 hover:text-white transition-colors duration-300" aria-label="Facebook">
+                        {{-- Heroicon: Facebook (custom simple path) --}}
+                        <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24"><path d="M9 8h-3v4h3v12h5v-12h3.642l.358-4h-4v-1.667c0-.955.192-1.333 1.115-1.333h2.885v-5h-3.808c-3.596 0-5.192 1.583-5.192 4.615v3.385z"/></svg>
+                    </a>
+                    <a href="#" class="text-gray-400 hover:text-white transition-colors duration-300" aria-label="Twitter">
+                        {{-- Heroicon: Twitter (custom simple path) --}}
+                        <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24"><path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-.422.724-.665 1.56-.665 2.452 0 1.606.817 3.022 2.059 3.855-.758-.023-1.47-.231-2.096-.58v.06c0 2.238 1.592 4.103 3.7 4.53-.387.105-.796.16-1.21.16-.299 0-.588-.028-.87-.083.588 1.839 2.295 3.178 4.322 3.215-1.581 1.238-3.576 1.975-5.752 1.975-.375 0-.743-.022-1.107-.065 2.042 1.318 4.473 2.088 7.08 2.088 7.495 0 12.015-6.534 11.29-12.815.804-.583 1.498-1.312 2.04-2.125z"/></svg>
+                    </a>
+                    <a href="#" class="text-gray-400 hover:text-white transition-colors duration-300" aria-label="Instagram">
+                        {{-- Heroicon: Instagram (custom simple path) --}}
+                        <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.069-4.85.069-3.204 0-3.584-.012-4.849-.069-3.224-.148-4.771-1.664-4.919-4.919-.058-1.265-.069-1.645-.069-4.849 0-3.204.013-3.583.069-4.849.149-3.227 1.664-4.771 4.919-4.919.058-1.265.069-1.645.069-4.849zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948s.014 3.667.072 4.947c.2 4.359 2.618 6.78 6.98 6.98 1.281.059 1.689.073 4.948.073s3.667-.014 4.947-.072c4.359-.2 6.78-2.618 6.98-6.98.059-1.281.073-1.689.073-4.948s-.014-3.667-.072-4.947c-.2-4.359-2.618-6.78-6.98-6.98-1.281-.059-1.689-.073-4.948-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.162 6.162 6.162 6.162-2.759 6.162-6.162-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4s1.791-4 4-4 4 1.79 4 4-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
+                    </a>
+                    <a href="#" class="text-gray-400 hover:text-white transition-colors duration-300" aria-label="LinkedIn">
+                        {{-- Heroicon: LinkedIn (custom simple path) --}}
+                        <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24"><path d="M4.98 3.5c0 1.381-1.11 2.5-2.48 2.5s-2.48-1.119-2.48-2.5c0-1.38 1.11-2.5 2.48-2.5s2.48 1.12 2.48 2.5zm.02 4.5h-5v16h5v-16zm7.982 0h-4.968v16h4.969v-8.399c0-4.67 6.029-5.052 6.029 0v8.399h4.988v-10.131c0-7.88-8.922-7.594-11.018-3.714v-2.155z"/></svg>
+                    </a>
+                </div>
+            </div>
+
+            {{-- Colonne 2: Liens Rapides --}}
+            <div class="mb-6 md:mb-0">
+                <h5 class="text-xl font-semibold text-white mb-4">Liens Rapides</h5>
+                <ul class="space-y-2">
+                    <li><a href="{{ route('ecommerce.home') }}" class="text-gray-400 hover:text-white transition-colors duration-300 text-sm">Accueil Boutique</a></li>
+                    <li><a href="{{ url('/produits') }}" class="text-gray-400 hover:text-white transition-colors duration-300 text-sm">Tous les Produits</a></li>
+                    <li><a href="{{ url('/promotions') }}" class="text-gray-400 hover:text-white transition-colors duration-300 text-sm">Promotions</a></li>
+                    <li><a href="{{ route('ecommerce.cart.index') }}" class="text-gray-400 hover:text-white transition-colors duration-300 text-sm">Mon Panier</a></li>
+                    <li><a href="{{ route('ecommerce.order.track') }}" class="text-gray-400 hover:text-white transition-colors duration-300 text-sm">Suivre ma Commande</a></li>
                 </ul>
             </div>
-            <div class="col-lg-3 col-md-6 mb-4 mb-lg-0">
-                <h5 class="text-uppercase mb-3">Liens Rapides</h5>
-                <ul class="list-unstyled">
-                    <li><a href="{{ route('ecommerce.home') }}" class="text-muted">Accueil Boutique</a></li>
-                    <li><a href="#" class="text-muted">Tous les Produits</a></li>
-                    <li><a href="#" class="text-muted">Promotions</a></li>
-                    <li><a href="{{ route('ecommerce.cart.index') }}" class="text-muted">Mon Panier</a></li>
-                    <li><a href="{{ route('ecommerce.order.track') }}" class="text-muted">Suivre ma Commande</a></li>
+
+            {{-- Colonne 3: Service Client --}}
+            <div class="mb-6 md:mb-0">
+                <h5 class="text-xl font-semibold text-white mb-4">Service Client</h5>
+                <ul class="space-y-2">
+                    <li><a href="{{ url('/contact') }}" class="text-gray-400 hover:text-white transition-colors duration-300 text-sm">Contactez-nous</a></li>
+                    <li><a href="{{ url('/faq') }}" class="text-gray-400 hover:text-white transition-colors duration-300 text-sm">FAQ</a></li>
+                    <li><a href="{{ url('/politique-retour') }}" class="text-gray-400 hover:text-white transition-colors duration-300 text-sm">Politique de Retour</a></li>
+                    <li><a href="{{ url('/cgv') }}" class="text-gray-400 hover:text-white transition-colors duration-300 text-sm">Conditions Générales de Vente</a></li>
+                    <li><a href="{{ url('/confidentialite') }}" class="text-gray-400 hover:text-white transition-colors duration-300 text-sm">Politique de Confidentialité</a></li>
                 </ul>
             </div>
-            <div class="col-lg-3 col-md-6 mb-4 mb-lg-0">
-                <h5 class="text-uppercase mb-3">Service Client</h5>
-                <ul class="list-unstyled">
-                    <li><a href="#" class="text-muted">Contactez-nous</a></li>
-                    <li><a href="#" class="text-muted">FAQ</a></li>
-                    <li><a href="#" class="text-muted">Politique de Retour</a></li>
-                    <li><a href="#" class="text-muted">Conditions Générales de Vente</a></li>
-                    <li><a href="#" class="text-muted">Politique de Confidentialité</a></li>
-                </ul>
-            </div>
-            <div class="col-lg-3 col-md-6">
-                <h5 class="text-uppercase mb-3">Contact Info</h5>
-                <ul class="list-unstyled text-muted">
-                    <li><i class="fas fa-map-marker-alt me-2"></i> 123 Rue de l'Exemple, Ville, Pays</li>
-                    <li><i class="fas fa-phone me-2"></i> +33 1 23 45 67 89</li>
-                    <li><i class="fas fa-envelope me-2"></i> contact@gestlogshop.com</li>
+
+            {{-- Colonne 4: Contact Info --}}
+            <div>
+                <h5 class="text-xl font-semibold text-white mb-4">Contact Info</h5>
+                <ul class="space-y-3 text-gray-400 text-sm">
+                    <li class="flex items-start">
+                        {{-- Heroicon: MapPin --}}
+                        <svg class="w-5 h-5 mr-2 mt-0.5 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9.69 18.933l.003.001C9.89 19.02 10 19 10 19s.11.02.308-.066l.002-.001.006-.003.018-.008a5.741 5.741 0 00.281-.145l.002-.001L10 18.48l-.308.453a5.741 5.741 0 00.281.145l.018.008.006.003zM10 16.57c1.514 0 2.75 1.236 2.75 2.75S11.514 22 10 22s-2.75-1.236-2.75-2.75S8.486 16.57 10 16.57zM10 0C5.582 0 2 3.582 2 8c0 1.993.805 3.814 2.123 5.178L10 20l5.877-6.822C17.195 11.814 18 9.993 18 8c0-4.418-3.582-8-8-8zm0 12a4 4 0 110-8 4 4 0 010 8z" clip-rule="evenodd" /></svg>
+                        <span>123 Rue de l'Exemple, 75000 Ville, Pays</span>
+                    </li>
+                    <li class="flex items-center">
+                        {{-- Heroicon: Phone --}}
+                        <svg class="w-5 h-5 mr-2 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z" /></svg>
+                        <span>+33 1 23 45 67 89</span>
+                    </li>
+                    <li class="flex items-center">
+                        {{-- Heroicon: Envelope --}}
+                        <svg class="w-5 h-5 mr-2 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path d="M3 4a2 2 0 00-2 2v8a2 2 0 002 2h14a2 2 0 002-2V6a2 2 0 00-2-2H3zm12 1a1 1 0 011 .883l-5.5 3.438-5.5-3.437A1 1 0 015 5h10z" /><path d="M16.5 7.534l-5.18 3.237a1.5 1.5 0 01-1.64 0L4.5 7.534V14a1 1 0 001 1h9a1 1 0 001-1V7.534z" /></svg>
+                        <span>contact@gestlogshop.com</span>
+                    </li>
                 </ul>
             </div>
         </div>
-        <hr class="my-3">
-        <div class="row">
-            <div class="col-md-6">
-                <p class="text-muted mb-0">
-                    &copy; {{ date('Y') }} {{ config('app.name', 'Gestlog') }}. Tous droits réservés.
-                </p>
-            </div>
-            <div class="col-md-6 text-md-end">
-                {{-- <img src="{{ asset('assets/img/payments.png') }}" alt="Moyens de paiement" height="30"> --}}
-                <p class="text-muted mb-0">Propulsé par KaiAdmin & Laravel</p>
-            </div>
+        <hr class="my-6 md:my-8 border-gray-700">
+        <div class="sm:flex sm:justify-between sm:items-center text-center sm:text-left">
+            <p class="text-sm text-gray-400 mb-4 sm:mb-0">
+                &copy; {{ date('Y') }} {{ config('app.name', 'Gestlog') }}. Tous droits réservés.
+            </p>
+            <p class="text-sm text-gray-400">
+                Propulsé avec <span class="text-red-400">&hearts;</span> par KaiAdmin & Laravel
+            </p>
         </div>
     </div>
 </footer>


### PR DESCRIPTION
J'ai implémenté la page d'accueil pour la section e-commerce de votre site, en utilisant le layout KaiAdmin adapté et TailwindCSS.

La page comprend les sections suivantes :
- Hero banner avec titre, slogan et CTA.
- Grille de catégories de produits.
- Section des produits phares/en promotion (6-8 produits).
- Avantages client avec icônes.
- Section "À propos" rapide.
- Footer adapté avec liens utiles et informations de contact.

Le design est responsive (mobile-first) et les composants Blade sont utilisés pour l'affichage dynamique des données (catégories, produits). Le code est commenté en français.