### PR TITLE
fix: corrige l'appel de la route product.show

### DIFF
--- a/resources/views/components/ecommerce/product-card.blade.php
+++ b/resources/views/components/ecommerce/product-card.blade.php
@@ -12,7 +12,7 @@
 <div class="card product-card h-100 shadow-sm">
     <div class="position-relative">
         {{-- Image du produit --}}
-        <a href="{{ route('ecommerce.product', ['slug' => $product->slug ?? $product['slug'] ?? '#']) }}">
+        <a href="{{ route('ecommerce.product.show', ['slug' => $product->slug ?? $product['slug'] ?? '#']) }}">
             <img src="{{ $product->image_url ?? $product['image_url'] ?? asset('assets/img/examples/product_placeholder.jpg') }}"
                  alt="Image de {{ $product->name ?? $product['name'] ?? 'Nom du produit' }}"
                  class="card-img-top product-card-img">
@@ -34,7 +34,7 @@
 
         {{-- Nom du produit --}}
         <h5 class="card-title fs-6 fw-medium mb-2 flex-grow-1">
-            <a href="{{ route('ecommerce.product', ['slug' => $product->slug ?? $product['slug'] ?? '#']) }}" class="text-dark text-decoration-none product-title-link">
+            <a href="{{ route('ecommerce.product.show', ['slug' => $product->slug ?? $product['slug'] ?? '#']) }}" class="text-dark text-decoration-none product-title-link">
                 {{ $product->name ?? $product['name'] ?? 'Nom du Produit Placeholder' }}
             </a>
         </h5>


### PR DESCRIPTION
Corrige le nom de la route utilisé dans le composant product-card pour afficher les détails d'un produit, passant de 'ecommerce.product' à 'ecommerce.product.show' pour correspondre à la définition dans routes/web.php.

Vérification des autres routes dans home.blade.php effectuée, RAS.