### PR TITLE
fix: corrige l'accès aux propriétés d'objet dans product-card

### DIFF
--- a/resources/views/components/ecommerce/product-card.blade.php
+++ b/resources/views/components/ecommerce/product-card.blade.php
@@ -12,40 +12,40 @@
 <div class="card product-card h-100 shadow-sm">
     <div class="position-relative">
         {{-- Image du produit --}}
-        <a href="{{ route('ecommerce.product.show', ['slug' => $product->slug ?? $product['slug'] ?? '#']) }}">
-            <img src="{{ $product->image_url ?? $product['image_url'] ?? asset('assets/img/examples/product_placeholder.jpg') }}"
-                 alt="Image de {{ $product->name ?? $product['name'] ?? 'Nom du produit' }}"
+        <a href="{{ route('ecommerce.product.show', ['slug' => $product->slug ?? '#']) }}">
+            <img src="{{ $product->image_url ?? asset('assets/img/examples/product_placeholder.jpg') }}"
+                 alt="Image de {{ $product->name ?? 'Nom du produit' }}"
                  class="card-img-top product-card-img">
         </a>
 
         {{-- Badge de promotion (optionnel) --}}
         @if(isset($product->est_en_promotion) && $product->est_en_promotion)
             <span class="badge bg-danger position-absolute top-0 start-0 m-2">PROMO</span>
-        @elseif(isset($product['badge_text']) && $product['badge_text']) {{-- Fallback pour un texte de badge custom --}}
-            <span class="badge bg-danger position-absolute top-0 start-0 m-2">{{ $product['badge_text'] }}</span>
+        @elseif(isset($product->badge_text) && $product->badge_text) {{-- Fallback pour un texte de badge custom --}}
+            <span class="badge bg-danger position-absolute top-0 start-0 m-2">{{ $product->badge_text }}</span>
         @endif
     </div>
 
     <div class="card-body d-flex flex-column">
         {{-- Catégorie du produit (optionnel) --}}
-        @if(isset($product->category_name) || isset($product['category_name']))
-            <p class="card-text text-muted small mb-1">{{ $product->category_name ?? $product['category_name'] }}</p>
+        @if(isset($product->category_name))
+            <p class="card-text text-muted small mb-1">{{ $product->category_name }}</p>
         @endif
 
         {{-- Nom du produit --}}
         <h5 class="card-title fs-6 fw-medium mb-2 flex-grow-1">
-            <a href="{{ route('ecommerce.product.show', ['slug' => $product->slug ?? $product['slug'] ?? '#']) }}" class="text-dark text-decoration-none product-title-link">
-                {{ $product->name ?? $product['name'] ?? 'Nom du Produit Placeholder' }}
+            <a href="{{ route('ecommerce.product.show', ['slug' => $product->slug ?? '#']) }}" class="text-dark text-decoration-none product-title-link">
+                {{ $product->name ?? 'Nom du Produit Placeholder' }}
             </a>
         </h5>
 
         {{-- Prix du produit --}}
         <div class="d-flex justify-content-between align-items-center mb-3">
             <p class="card-text fs-5 fw-bold mb-0 @if(isset($product->old_price) || (isset($product->est_en_promotion) && $product->est_en_promotion)) text-danger @else text-primary @endif">
-                {{ number_format($product->price ?? $product['price'] ?? 0, 2, ',', ' ') }} €
+                {{ number_format($product->price ?? 0, 2, ',', ' ') }} €
             </p>
             {{-- Ancien prix (si en promotion) --}}
-            @if(isset($product->old_price) && $product->old_price > ($product->price ?? $product['price'] ?? 0))
+            @if(isset($product->old_price) && $product->old_price > ($product->price ?? 0))
                 <p class="card-text text-muted text-decoration-line-through small mb-0 ms-2">
                     {{ number_format($product->old_price, 2, ',', ' ') }} €
                 </p>
@@ -57,8 +57,8 @@
             <button
                 type="button"
                 class="btn btn-primary w-100 add-to-cart-btn"
-                onclick="addToCart({{ $product->id ?? $product['id'] ?? 0 }})"
-                title="Ajouter {{ $product->name ?? $product['name'] ?? 'ce produit' }} au panier">
+                onclick="addToCart({{ $product->id ?? 0 }})"
+                title="Ajouter {{ $product->name ?? 'ce produit' }} au panier">
                 <i class="fas fa-shopping-cart me-1"></i> {{-- KaiAdmin utilise Font Awesome --}}
                 Ajouter au panier
             </button>


### PR DESCRIPTION
Modifie le composant product-card pour utiliser exclusivement la syntaxe objet (->) lors de l'accès aux propriétés de $product. Cela résout l'erreur "Cannot use object of type stdClass as array" qui survenait lorsque les données du produit étaient passées comme un objet stdClass (par exemple, depuis les données de simulation ou certaines requêtes DB).

Les fallbacks vers un accès de type tableau ont été supprimés.