### PR TITLE
Fix: Correction des références de route pour l'affichage produit

### DIFF
--- a/resources/views/components/ecommerce/product-card.blade.php
+++ b/resources/views/components/ecommerce/product-card.blade.php
@@ -12,7 +12,7 @@
 <div class="card product-card h-100 shadow-sm">
     <div class="position-relative">
         {{-- Image du produit --}}
-        <a href="{{ route('ecommerce.product.show', ['slug' => $product->slug ?? '#']) }}">
+        <a href="{{ route('ecommerce.produits.show', ['slug' => $product->slug ?? '#']) }}">
             <img src="{{ $product->image_url ?? asset('assets/img/examples/product_placeholder.jpg') }}"
                  alt="Image de {{ $product->name ?? 'Nom du produit' }}"
                  class="card-img-top product-card-img">
@@ -34,7 +34,7 @@
 
         {{-- Nom du produit --}}
         <h5 class="card-title fs-6 fw-medium mb-2 flex-grow-1">
-            <a href="{{ route('ecommerce.product.show', ['slug' => $product->slug ?? '#']) }}" class="text-dark text-decoration-none product-title-link">
+            <a href="{{ route('ecommerce.produits.show', ['slug' => $product->slug ?? '#']) }}" class="text-dark text-decoration-none product-title-link">
                 {{ $product->name ?? 'Nom du Produit Placeholder' }}
             </a>
         </h5>

--- a/resources/views/ecommerce/cart.blade.php
+++ b/resources/views/ecommerce/cart.blade.php
@@ -25,14 +25,14 @@
                             @foreach($cartItems as $item)
                                 <tr>
                                     <td style="width: 100px;">
-                                        <a href="{{ route('ecommerce.product.show', $item['slug']) }}">
+                                        <a href="{{ route('ecommerce.produits.show', ['slug' => $item['slug']]) }}">
                                             <img src="{{ $item['image_url'] ?? asset('assets/img/examples/product-default-thumb.jpg') }}"
                                                  alt="{{ $item['name'] }}" class="img-fluid rounded" style="max-height: 75px; object-fit: cover;">
                                         </a>
                                     </td>
                                     <td>
                                         <h5 class="mb-0 fs-6">
-                                            <a href="{{ route('ecommerce.product.show', $item['slug']) }}" class="text-dark text-decoration-none">{{ $item['name'] }}</a>
+                                            <a href="{{ route('ecommerce.produits.show', ['slug' => $item['slug']]) }}" class="text-dark text-decoration-none">{{ $item['name'] }}</a>
                                         </h5>
                                         {{-- <small class="text-muted">SKU: XYZ123</small> --}}
                                     </td>


### PR DESCRIPTION
- Remplacement de `ecommerce.product.show` par `ecommerce.produits.show` dans les vues Blade concernées pour correspondre à la définition de route correcte.

Précédemment :
- Finalisation interface e-commerce et routes.
- Correction et ajout des routes nécessaires dans routes/web.php pour la section e-commerce.
- Utilisation de routes nommées et commentaires pour clarification.
- Création des contrôleurs ProduitController, PanierController, CommandeController.
- Modification de CategorieController pour gérer l'affichage e-commerce.
- Création des vues Blade minimalistes pour produits, panier, commande, catégories et pages de fallback.
- Correction des liens et boutons dans home.blade.php et product-card.blade.php pour pointer vers les routes fonctionnelles.
- Ajout de commentaires dans le code pour une meilleure lisibilité.
- Assurer la navigabilité de base de la section e-commerce.
- Retrait des appels non standards `.comment()` des définitions de routes.