### PR TITLE
Fix: Correction propriété slug manquante dans simulation et refs routes

### DIFF
--- a/resources/views/ecommerce/home.blade.php
+++ b/resources/views/ecommerce/home.blade.php
@@ -155,7 +155,7 @@
                 // Simulation de données de catégories enrichies avec slug
                 if (!isset($categories)) {
                     $categories = collect([
-                        (object)['id' => 1, 'nom' => 'Électronique & High-Tech', 'image_url' => 'https://picsum.photos/seed/cat_electro/400/250'],
+                        (object)['id' => 1, 'nom' => 'Électronique & High-Tech', 'slug' => 'electronique-high-tech', 'image_url' => 'https://picsum.photos/seed/cat_electro/400/250'],
                         (object)['id' => 2, 'nom' => 'Mode & Tendances',        'slug' => 'mode-tendances',       'image_url' => 'https://picsum.photos/seed/cat_mode/400/250'],
                         (object)['id' => 3, 'nom' => 'Maison & Décoration',    'slug' => 'maison-decoration',    'image_url' => 'https://picsum.photos/seed/cat_maison/400/250'],
                         (object)['id' => 4, 'nom' => 'Sport & Aventure',       'slug' => 'sport-aventure',       'image_url' => 'https://picsum.photos/seed/cat_sport/400/250'],


### PR DESCRIPTION
- J'ai ajouté la propriété `slug` aux données de simulation pour les catégories dans `home.blade.php`.
- J'ai remplacé `ecommerce.product.show` par `ecommerce.produits.show` dans les vues Blade concernées pour correspondre à la définition de route correcte.

Précédemment :
- J'ai finalisé l'interface e-commerce et les routes.
- J'ai corrigé et ajouté les routes nécessaires dans routes/web.php pour la section e-commerce.
- J'ai utilisé des routes nommées et des commentaires pour clarification.
- J'ai créé les contrôleurs ProduitController, PanierController, CommandeController.
- J'ai modifié CategorieController pour gérer l'affichage e-commerce.
- J'ai créé les vues Blade minimalistes pour produits, panier, commande, catégories et pages de fallback.
- J'ai corrigé les liens et boutons dans home.blade.php et product-card.blade.php pour pointer vers les routes fonctionnelles.
- J'ai ajouté des commentaires dans le code pour une meilleure lisibilité.
- J'ai assuré la navigabilité de base de la section e-commerce.
- J'ai retiré les appels non standards `.comment()` des définitions de routes.