### PR TITLE
feat: Replace e-commerce header with a new design

### DIFF
--- a/public/assets/css/custom-ecommerce.css
+++ b/public/assets/css/custom-ecommerce.css
@@ -21,6 +21,73 @@
     --border-radius: 0.375rem; /* 6px, correspond à .rounded de Bootstrap 5 */
 }
 
+/* --- Styles for the new header --- */
+
+.sticky-top {
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+    z-index: 1020;
+}
+
+.bg-dark {
+    background-color: #212529 !important;
+}
+
+.shadow-md {
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1);
+}
+
+.text-warning {
+    color: #ffc107 !important;
+}
+
+.text-success {
+    color: #198754 !important;
+}
+
+.hover-text-warning:hover {
+    color: #ffc107 !important;
+}
+
+.hover-bg-warning:hover {
+    background-color: #ffc107 !important;
+    color: #212529 !important;
+}
+
+.transition {
+    transition: all .2s ease-in-out;
+}
+
+.space-x-4 > *:not([hidden]) ~ *:not([hidden]) {
+    margin-left: 1rem;
+}
+
+.z-10 {
+    z-index: 10;
+}
+
+.z-50 {
+    z-index: 50;
+}
+
+.w-md-50 {
+    width: 50% !important;
+}
+
+.w-lg-33 {
+    width: 33.333333% !important;
+}
+
+@media (max-width: 767.98px) {
+    .w-md-50 {
+        width: 100% !important;
+    }
+    .w-lg-33 {
+        width: 100% !important;
+    }
+}
+
 /* Styles de base pour la page d'accueil */
 .home-page {
     overflow-x: hidden; /* Empêcher le défilement horizontal accidentel */

--- a/resources/views/ecommerce/partials/header.blade.php
+++ b/resources/views/ecommerce/partials/header.blade.php
@@ -1,197 +1,70 @@
-<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
-    <div class="container">
-        <a class="navbar-brand" href="{{ route('ecommerce.home') }}">
-            <img src="{{ asset('assets/img/logoproduct.svg') }}" alt="{{ config('app.name', 'Gestlog') }} E-commerce" height="30">
-            {{ config('app.name', 'Gestlog') }} Boutique
-        </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarNavDropdown">
-            <ul class="navbar-nav ms-auto align-items-center">
-                <li class="nav-item">
-                    <a class="nav-link {{ request()->routeIs('ecommerce.home') ? 'active' : '' }}" href="{{ route('ecommerce.home') }}">Accueil</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link {{ request()->routeIs('ecommerce.articles.index') ? 'active' : '' }}" href="{{ route('ecommerce.articles.index') }}">Catalogue</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="#">Promotions</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="#">Contact</a>
-                </li>
-                 <li class="nav-item">
-                    <a class="nav-link {{ request()->routeIs('ecommerce.order.track') ? 'active' : '' }}" href="{{ route('ecommerce.order.track') }}">Suivre ma commande</a>
-                </li>
+<header class="bg-dark shadow-md sticky-top z-50">
+    <div class="container mx-auto px-4 py-3">
+        <div class="d-flex flex-column flex-md-row align-items-center justify-content-between">
+            <!-- Logo et Badge -->
+            <div class="d-flex align-items-center mb-3 mb-md-0">
+                <a href="{{ route('ecommerce.home') }}" class="text-decoration-none">
+                    <h1 class="h4 text-white mb-0">
+                        <span class="fw-bold text-warning">LOGO</span><span class="text-success">Shop</span>
+                    </h1>
+                </a>
+                <span class="ms-3 badge bg-warning text-white" data-testid="badge-burkinabe">
+                    100% Burkinabé
+                </span>
+            </div>
 
-                {{-- Recherche Asynchrone --}}
-                <li class="nav-item ms-3 search-container">
-                    <form class="d-flex" action="{{ route('ecommerce.articles.index') }}" method="GET" id="live-search-form">
-                        <input class="form-control me-2" type="search" name="search" id="live-search-input" placeholder="Rechercher un article..." aria-label="Search" autocomplete="off" value="{{ request('search') }}">
-                        <button class="btn btn-outline-primary" type="submit"><i class="fas fa-search"></i></button>
-                    </form>
-                    <div id="search-results" class="search-results-box"></div>
-                </li>
+            <!-- Barre de recherche -->
+            <div class="w-100 w-md-50 w-lg-33 mb-3 mb-md-0 position-relative">
+                <form action="{{ route('ecommerce.articles.index') }}" method="GET" id="live-search-form">
+                    <input type="text" name="search" id="live-search-input" placeholder="Rechercher un produit, une marque ou une catégorie..."
+                           class="form-control form-control-lg"
+                           data-testid="search-bar" autocomplete="off" value="{{ request('search') }}">
+                </form>
+                <div class="position-absolute start-0 end-0 mt-1 bg-white border border-light rounded-lg shadow-lg z-10 d-none" id="search-results">
+                    <!-- item: <a href="#" class="d-block px-4 py-2 text-decoration-none text-dark hover-bg-light">Suggestion 1</a> -->
+                </div>
+            </div>
 
-
-                <li class="nav-item ms-3 dropdown">
-                    <a class="nav-link btn btn-icon btn-round btn-primary dropdown-toggle" href="#" id="cartDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" title="Voir le panier">
-                        <i class="fas fa-shopping-cart"></i>
-                        <span class="badge bg-danger cart-count-badge"></span>
-                    </a>
-                    <div class="dropdown-menu dropdown-menu-end mini-cart-dropdown" aria-labelledby="cartDropdown" id="mini-cart-container">
-                        {{-- Le contenu du mini-panier sera chargé ici par AJAX/au chargement de la page --}}
-                        @include('ecommerce.partials._mini-cart')
-                    </div>
-                </li>
-            </ul>
+            <!-- Icônes utilisateur, panier, favoris -->
+            <div class="d-flex align-items-center space-x-4">
+                <a href="#" class="text-white hover-text-warning" aria-label="Mon compte" data-testid="icon-user">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-person" viewBox="0 0 16 16">
+                        <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm2-3a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm4 8c0 1-1 1-1 1H3s-1 0-1-1 1-4 6-4 6 3 6 4zm-1-.004c-.001-.246-.154-.986-.832-1.664C11.516 10.68 10.289 10 8 10c-2.29 0-3.516.68-4.168 1.332-.678.678-.83 1.418-.832 1.664h10z"/>
+                    </svg>
+                </a>
+                <a href="{{ route('ecommerce.panier.index') }}" class="text-white hover-text-warning position-relative" aria-label="Panier" data-testid="icon-cart">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-cart" viewBox="0 0 16 16">
+                        <path d="M0 1.5A.5.5 0 0 1 .5 1H2a.5.5 0 0 1 .485.379L2.89 3H14.5a.5.5 0 0 1 .491.592l-1.5 8A.5.5 0 0 1 13 12H4a.5.5 0 0 1-.491-.408L2.01 3.607 1.61 2H.5a.5.5 0 0 1-.5-.5zM3.102 4l1.313 7h8.17l1.313-7H3.102zM5 12a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm7 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm-7 1a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm7 1a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+                    </svg>
+                    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger cart-count-badge" data-testid="cart-count"></span>
+                </a>
+                <a href="#" class="text-white hover-text-warning" aria-label="Favoris" data-testid="icon-wishlist">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-heart" viewBox="0 0 16 16">
+                        <path d="m8 2.748-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385.92 1.815 2.834 3.989 6.286 6.357 3.452-2.368 5.365-4.542 6.286-6.357.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01L8 2.748zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143c.06.055.119.112.176.171a3.12 3.12 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15z"/>
+                    </svg>
+                </a>
+            </div>
         </div>
+
+        <!-- Menu catégories -->
+        <nav class="mt-3 border-top border-secondary pt-3">
+            <ul class="d-flex flex-wrap justify-content-center justify-content-md-start list-unstyled">
+                @php
+                    $categories = \App\Models\Categorie::all();
+                @endphp
+                @foreach($categories as $category)
+                    <li class="me-2 me-md-4">
+                        <a href="{{ route('ecommerce.categories.show', ['slug' => $category->slug]) }}"
+                           class="text-white text-decoration-none fw-semibold px-3 py-1 rounded-pill hover-bg-warning transition"
+                           data-testid="category-link-{{ $category->slug }}">
+                            {{ $category->name }}
+                        </a>
+                    </li>
+                @endforeach
+            </ul>
+        </nav>
     </div>
-</nav>
-
-{{-- Placeholder pour compenser la hauteur du fixed-top navbar --}}
-<div style="padding-top: 70px;"></div>
-
-{{-- Scripts --}}
-@push('styles')
-<style>
-    /* Amélioration du badge du panier */
-    .nav-item.dropdown .btn-primary {
-        position: relative;
-    }
-    .cart-count-badge {
-        position: absolute;
-        top: -5px;
-        right: -10px;
-        font-size: 10px;
-        width: 20px;
-        height: 20px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        border-radius: 50%;
-        padding: 0;
-    }
-
-    .mini-cart-dropdown {
-        min-width: 300px;
-        padding: 0;
-    }
-    .mini-cart-list {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-        max-height: 250px;
-        overflow-y: auto;
-    }
-    .mini-cart-item {
-        border-bottom: 1px solid #eee;
-    }
-    .mini-cart-item-link {
-        display: flex;
-        align-items: center;
-        padding: 10px;
-        text-decoration: none;
-        color: #333;
-    }
-    .mini-cart-item-link:hover {
-        background-color: #f8f9fa;
-    }
-    .mini-cart-item-img {
-        width: 50px;
-        height: 50px;
-        object-fit: cover;
-        margin-right: 10px;
-    }
-    .mini-cart-item-details {
-        display: flex;
-        flex-direction: column;
-    }
-    .mini-cart-item-name {
-        font-weight: bold;
-    }
-    .mini-cart-item-price {
-        font-size: 0.9em;
-        color: #6c757d;
-    }
-    .mini-cart-footer {
-        padding: 10px;
-        border-top: 1px solid #ddd;
-    }
-    .mini-cart-total {
-        display: flex;
-        justify-content: space-between;
-        font-size: 1.1em;
-        margin-bottom: 10px;
-    }
-    .mini-cart-actions {
-        display: flex;
-        justify-content: space-between;
-    }
-    .mini-cart-empty {
-        text-align: center;
-        padding: 20px;
-    }
-
-    .search-container {
-        position: relative;
-    }
-    .search-results-box {
-        display: none;
-        position: absolute;
-        top: 100%;
-        left: 0;
-        width: 100%;
-        background-color: #fff;
-        border: 1px solid #ddd;
-        border-radius: 0 0 .25rem .25rem;
-        box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-        z-index: 1000;
-        max-height: 300px;
-        overflow-y: auto;
-    }
-    .search-result-item {
-        display: flex;
-        align-items: center;
-        padding: 0.5rem 0.75rem;
-        text-decoration: none;
-        color: #333;
-        border-bottom: 1px solid #eee;
-    }
-    .search-result-item:hover {
-        background-color: #f8f9fa;
-    }
-    .search-result-item:last-child {
-        border-bottom: none;
-    }
-    .search-result-img {
-        width: 40px;
-        height: 40px;
-        object-fit: cover;
-        margin-right: 10px;
-        border-radius: .25rem;
-    }
-    .search-result-item-none {
-        padding: 1rem;
-        color: #6c757d;
-        text-align: center;
-        font-style: italic;
-    }
-    .search-result-footer {
-        display: block;
-        text-align: center;
-        padding: 0.75rem;
-        background-color: #f8f9fa;
-        color: var(--bs-primary);
-        font-weight: bold;
-        text-decoration: none;
-    }
-    .search-result-footer:hover {
-        background-color: #e9ecef;
-    }
-</style>
-@endpush
+</header>
 
 @push('scripts')
 <script>
@@ -209,7 +82,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const query = this.value;
 
         if (query.length < 2) {
-            searchResults.style.display = 'none';
+            searchResults.classList.add('d-none');
             return;
         }
 
@@ -221,19 +94,19 @@ document.addEventListener('DOMContentLoaded', function () {
                     if (data.length > 0) {
                         data.forEach(item => {
                             const resultItem = `
-                                <a href="${item.url}" class="search-result-item">
-                                    <img src="${item.image || '{{ asset('assets/img/examples/article_placeholder_thumb.jpg') }}'}" alt="" class="search-result-img">
+                                <a href="${item.url}" class="d-block px-4 py-2 text-decoration-none text-dark hover-bg-light">
+                                    <img src="${item.image || '{{ asset('assets/img/examples/article_placeholder_thumb.jpg') }}'}" alt="" width="40" height="40" class="me-2 rounded">
                                     <span>${item.name}</span>
                                 </a>
                             `;
                             searchResults.innerHTML += resultItem;
                         });
                         // Ajout du lien "Voir tous les résultats"
-                        searchResults.innerHTML += `<a href="/shop/articles?search=${query}" class="search-result-footer">Voir tous les résultats</a>`;
+                        searchResults.innerHTML += `<a href="/shop/articles?search=${query}" class="d-block text-center fw-bold p-2 bg-light text-primary text-decoration-none">Voir tous les résultats</a>`;
                     } else {
-                        searchResults.innerHTML = '<div class="search-result-item-none">Aucun article ne correspond à votre recherche.</div>';
+                        searchResults.innerHTML = '<div class="p-3 text-muted text-center">Aucun article ne correspond à votre recherche.</div>';
                     }
-                    searchResults.style.display = 'block';
+                    searchResults.classList.remove('d-none');
                 })
                 .catch(error => console.error('Erreur de recherche:', error));
         }, 300); // Délai de 300ms avant de lancer la recherche
@@ -241,8 +114,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // Cacher les résultats si on clique en dehors
     document.addEventListener('click', function(event) {
-        if (!document.querySelector('.search-container').contains(event.target)) {
-            searchResults.style.display = 'none';
+        const searchContainer = document.querySelector('.position-relative');
+        if (!searchContainer.contains(event.target)) {
+            searchResults.classList.add('d-none');
         }
     });
 });

--- a/resources/views/ecommerce/partials/header.blade.php.bak
+++ b/resources/views/ecommerce/partials/header.blade.php.bak
@@ -1,0 +1,263 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+    <div class="container">
+        <a class="navbar-brand" href="{{ route('ecommerce.home') }}">
+            <img src="{{ asset('assets/img/logoproduct.svg') }}" alt="{{ config('app.name', 'Gestlog') }} E-commerce" height="30">
+            {{ config('app.name', 'Gestlog') }} Boutique
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNavDropdown">
+            <ul class="navbar-nav ms-auto align-items-center">
+                <li class="nav-item">
+                    <a class="nav-link {{ request()->routeIs('ecommerce.home') ? 'active' : '' }}" href="{{ route('ecommerce.home') }}">Accueil</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link {{ request()->routeIs('ecommerce.articles.index') ? 'active' : '' }}" href="{{ route('ecommerce.articles.index') }}">Catalogue</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="#">Promotions</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="#">Contact</a>
+                </li>
+                 <li class="nav-item">
+                    <a class="nav-link {{ request()->routeIs('ecommerce.order.track') ? 'active' : '' }}" href="{{ route('ecommerce.order.track') }}">Suivre ma commande</a>
+                </li>
+
+                {{-- Recherche Asynchrone --}}
+                <li class="nav-item ms-3 search-container">
+                    <form class="d-flex" action="{{ route('ecommerce.articles.index') }}" method="GET" id="live-search-form">
+                        <input class="form-control me-2" type="search" name="search" id="live-search-input" placeholder="Rechercher un article..." aria-label="Search" autocomplete="off" value="{{ request('search') }}">
+                        <button class="btn btn-outline-primary" type="submit"><i class="fas fa-search"></i></button>
+                    </form>
+                    <div id="search-results" class="search-results-box"></div>
+                </li>
+
+
+                <li class="nav-item ms-3 dropdown">
+                    <a class="nav-link btn btn-icon btn-round btn-primary dropdown-toggle" href="#" id="cartDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" title="Voir le panier">
+                        <i class="fas fa-shopping-cart"></i>
+                        <span class="badge bg-danger cart-count-badge"></span>
+                    </a>
+                    <div class="dropdown-menu dropdown-menu-end mini-cart-dropdown" aria-labelledby="cartDropdown" id="mini-cart-container">
+                        {{-- Le contenu du mini-panier sera chargé ici par AJAX/au chargement de la page --}}
+                        @include('ecommerce.partials._mini-cart')
+                    </div>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>
+
+{{-- Placeholder pour compenser la hauteur du fixed-top navbar --}}
+<div style="padding-top: 70px;"></div>
+
+{{-- Scripts --}}
+@push('styles')
+<style>
+    /* Amélioration du badge du panier */
+    .nav-item.dropdown .btn-primary {
+        position: relative;
+    }
+    .cart-count-badge {
+        position: absolute;
+        top: -5px;
+        right: -10px;
+        font-size: 10px;
+        width: 20px;
+        height: 20px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        border-radius: 50%;
+        padding: 0;
+    }
+
+    .mini-cart-dropdown {
+        min-width: 300px;
+        padding: 0;
+    }
+    .mini-cart-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        max-height: 250px;
+        overflow-y: auto;
+    }
+    .mini-cart-item {
+        border-bottom: 1px solid #eee;
+    }
+    .mini-cart-item-link {
+        display: flex;
+        align-items: center;
+        padding: 10px;
+        text-decoration: none;
+        color: #333;
+    }
+    .mini-cart-item-link:hover {
+        background-color: #f8f9fa;
+    }
+    .mini-cart-item-img {
+        width: 50px;
+        height: 50px;
+        object-fit: cover;
+        margin-right: 10px;
+    }
+    .mini-cart-item-details {
+        display: flex;
+        flex-direction: column;
+    }
+    .mini-cart-item-name {
+        font-weight: bold;
+    }
+    .mini-cart-item-price {
+        font-size: 0.9em;
+        color: #6c757d;
+    }
+    .mini-cart-footer {
+        padding: 10px;
+        border-top: 1px solid #ddd;
+    }
+    .mini-cart-total {
+        display: flex;
+        justify-content: space-between;
+        font-size: 1.1em;
+        margin-bottom: 10px;
+    }
+    .mini-cart-actions {
+        display: flex;
+        justify-content: space-between;
+    }
+    .mini-cart-empty {
+        text-align: center;
+        padding: 20px;
+    }
+
+    .search-container {
+        position: relative;
+    }
+    .search-results-box {
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        width: 100%;
+        background-color: #fff;
+        border: 1px solid #ddd;
+        border-radius: 0 0 .25rem .25rem;
+        box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        z-index: 1000;
+        max-height: 300px;
+        overflow-y: auto;
+    }
+    .search-result-item {
+        display: flex;
+        align-items: center;
+        padding: 0.5rem 0.75rem;
+        text-decoration: none;
+        color: #333;
+        border-bottom: 1px solid #eee;
+    }
+    .search-result-item:hover {
+        background-color: #f8f9fa;
+    }
+    .search-result-item:last-child {
+        border-bottom: none;
+    }
+    .search-result-img {
+        width: 40px;
+        height: 40px;
+        object-fit: cover;
+        margin-right: 10px;
+        border-radius: .25rem;
+    }
+    .search-result-item-none {
+        padding: 1rem;
+        color: #6c757d;
+        text-align: center;
+        font-style: italic;
+    }
+    .search-result-footer {
+        display: block;
+        text-align: center;
+        padding: 0.75rem;
+        background-color: #f8f9fa;
+        color: var(--bs-primary);
+        font-weight: bold;
+        text-decoration: none;
+    }
+    .search-result-footer:hover {
+        background-color: #e9ecef;
+    }
+</style>
+@endpush
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    // Mise à jour du compteur de panier
+    fetchCartCount();
+
+    // Logique de recherche en direct
+    const searchInput = document.getElementById('live-search-input');
+    const searchResults = document.getElementById('search-results');
+    let searchTimeout;
+
+    searchInput.addEventListener('input', function () {
+        clearTimeout(searchTimeout);
+        const query = this.value;
+
+        if (query.length < 2) {
+            searchResults.style.display = 'none';
+            return;
+        }
+
+        searchTimeout = setTimeout(() => {
+            fetch(`/shop/search?query=${query}`)
+                .then(response => response.json())
+                .then(data => {
+                    searchResults.innerHTML = '';
+                    if (data.length > 0) {
+                        data.forEach(item => {
+                            const resultItem = `
+                                <a href="${item.url}" class="search-result-item">
+                                    <img src="${item.image || '{{ asset('assets/img/examples/article_placeholder_thumb.jpg') }}'}" alt="" class="search-result-img">
+                                    <span>${item.name}</span>
+                                </a>
+                            `;
+                            searchResults.innerHTML += resultItem;
+                        });
+                        // Ajout du lien "Voir tous les résultats"
+                        searchResults.innerHTML += `<a href="/shop/articles?search=${query}" class="search-result-footer">Voir tous les résultats</a>`;
+                    } else {
+                        searchResults.innerHTML = '<div class="search-result-item-none">Aucun article ne correspond à votre recherche.</div>';
+                    }
+                    searchResults.style.display = 'block';
+                })
+                .catch(error => console.error('Erreur de recherche:', error));
+        }, 300); // Délai de 300ms avant de lancer la recherche
+    });
+
+    // Cacher les résultats si on clique en dehors
+    document.addEventListener('click', function(event) {
+        if (!document.querySelector('.search-container').contains(event.target)) {
+            searchResults.style.display = 'none';
+        }
+    });
+});
+
+function fetchCartCount() {
+    fetch('{{ route("ecommerce.panier.count") }}')
+        .then(response => response.json())
+        .then(data => {
+            const cartBadge = document.querySelector('.cart-count-badge');
+            if (cartBadge) {
+                cartBadge.textContent = data.count > 0 ? data.count : '';
+                cartBadge.style.display = data.count > 0 ? 'inline-block' : 'none';
+            }
+        })
+        .catch(error => console.error('Erreur lors de la récupération du nombre d\'articles du panier:', error));
+}
+</script>
+@endpush


### PR DESCRIPTION
This commit replaces the old Bootstrap-based header in the e-commerce section with a new, more modern design. The new header is inspired by your example and includes a functional search bar with live search capabilities.

- The old header file has been backed up to `header.blade.php.bak`.
- A new `header.blade.php` has been created with the new HTML structure.
- Custom CSS has been added to `custom-ecommerce.css` to style the new header and ensure responsiveness.
- The routes in the header have been updated to match the application's routes.